### PR TITLE
Fix numeric field overflow

### DIFF
--- a/migrations/versions/2a4073217d5d_size_numeric_overflow.py
+++ b/migrations/versions/2a4073217d5d_size_numeric_overflow.py
@@ -1,0 +1,25 @@
+"""Size column with numeric overflow (https://github.com/andreoliwa/scrapy-tegenaria/issues/225).
+
+Create Date: 2017-10-27 01:16:21.177093
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = '2a4073217d5d'
+down_revision = '87be69f7b2e2'
+
+
+def upgrade():
+    """Apply changes to a database (create tables, columns, etc.)."""
+    op.alter_column('apartment', 'size',
+                    existing_type=sa.NUMERIC(precision=6, scale=2),
+                    type_=sa.Numeric(precision=7, scale=2),
+                    existing_nullable=True)
+
+
+def downgrade():
+    """Reverse actions performed during upgrade."""
+    op.alter_column('apartment', 'size',
+                    existing_type=sa.Numeric(precision=7, scale=2),
+                    type_=sa.NUMERIC(precision=6, scale=2),
+                    existing_nullable=True)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,7 +15,6 @@ ipdb==0.10.3
 coverage==4.4.1
 pytest-cov==2.5.1
 Sphinx==1.6.5
-pur==4.0.2
 
 # Lint and code style
 flake8==3.5.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -25,7 +25,7 @@ flask-marshmallow==0.8.0
 # Database
 Flask-SQLAlchemy==2.3.2
 SQLAlchemy==1.1.14
-psycopg2==2.7.3.1
+psycopg2==2.7.3.2
 marshmallow-sqlalchemy==0.13.2
 
 # Migrations

--- a/tegenaria/models.py
+++ b/tegenaria/models.py
@@ -17,7 +17,7 @@ class Apartment(SurrogatePK, Model):
     address = Column(db.String())
     neighborhood = Column(db.String())
     rooms = Column(db.Numeric(3, 1))
-    size = Column(db.Numeric(6, 2))
+    size = Column(db.Numeric(7, 2))
 
     # Prices
     cold_rent_price = Column(db.Numeric(10, 2))

--- a/tegenaria/spiders/immo_net.py
+++ b/tegenaria/spiders/immo_net.py
@@ -27,10 +27,10 @@ class ImmoNetSpider(CrawlSpider, SpiderMixin):
     def parse_item(self, response):
         """Parse the flat response.
 
-        @url https://www.immonet.de/angebot/30517909?drop=sel&related=false
+        @url https://www.immonet.de/angebot/31010622?drop=sel&related=false
         @returns items 1 1
-        @scrapes url title address rooms size cold_rent_price warm_rent_price additional_price heating_price
-        @scrapes description equipment location other
+        @scrapes url title address rooms size cold_rent_price warm_rent_price additional_price description
+        @scrapes equipment location
         """
         self.shutdown_on_error()
         item = ItemLoader(ApartmentItem(), response=response)


### PR DESCRIPTION
2017-10-26 11:08:25 [scrapy.core.engine] INFO: Spider closed ((psycopg2.DataError) numeric field overflow
    DETAIL:  A field with precision 6, scale 2 must round to an absolute value less than 10^4.
     [SQL: 'INSERT INTO apartment (url, active, title, address, neighborhood, rooms, size, cold_rent_price, warm_rent_price, additional_price, heating_price, opinion_id, description, equipment, location, other, availability, comments, json, errors, created_at, updated_at) VALUES (%(url)s,)'])